### PR TITLE
Fix Riposje advantage logic

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -78,15 +78,18 @@ class ImperialDuelGame:
         
         # Calculate delta: (idx2 - idx1) mod 6
         delta = (idx2 - idx1) % 6
-        
+
         if delta in [1, 2]:
             # stance1 has advantage over stance2
             return "advantage", "disadvantage"
         elif delta == 5:
-            # stance1 has disadvantage vs stance2 (only delta 5, not 4)
+            # stance1 has disadvantage vs stance2 (counter-clockwise adjacent)
             return "disadvantage", "advantage"
+        elif delta == 4:
+            # stance2 has advantage over stance1 while stance1 remains neutral
+            return "neutral", "advantage"
         else:
-            # neutral (delta == 0, 3, or 4)
+            # neutral (delta == 0 or 3)
             return "neutral", "neutral"
     
     def are_stances_adjacent(self, stance1: str, stance2: str) -> bool:

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -21,7 +21,7 @@ def test_stance_relationships():
         ("Bagr", "Radae", "advantage", "disadvantage"),  # Bagr has advantage over Radae
         ("Bagr", "Darda", "advantage", "disadvantage"),  # Bagr has advantage over Darda
         ("Bagr", "Tigr", "neutral", "neutral"),          # Bagr is neutral to Tigr
-        ("Bagr", "Riposje", "neutral", "neutral"),       # Bagr is neutral to Riposje
+        ("Bagr", "Riposje", "neutral", "advantage"),     # Riposje should have advantage over Bagr
         ("Bagr", "Tortad", "disadvantage", "advantage"), # Bagr has disadvantage vs Tortad
         ("Riposje", "Bagr", "advantage", "disadvantage"), # Riposje should beat Bagr
     ]


### PR DESCRIPTION
## Summary
- adjust stance relationship logic so Riposje gains advantage over Bagr
- update unit test to cover new relationship

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0d7b8f588326812609c5fc41d19a