### PR TITLE
Improve tie display

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -942,9 +942,37 @@ async def resolve_round(interaction: discord.Interaction, match: Match):
         result.player2_final_roll,
         result.player2_modifier
     )
-    
+
+
+    if result.tie_rerolled:
+        p1_initial_text = format_roll_details(
+            match.player1.username,
+            result.player1_advantage,
+            result.initial_player1_all_rolls,
+            result.initial_player1_used_roll_index,
+            result.initial_player1_roll,
+            result.initial_player1_final_roll,
+            result.player1_modifier,
+        )
+
+        p2_initial_text = format_roll_details(
+            match.player2.username,
+            result.player2_advantage,
+            result.initial_player2_all_rolls,
+            result.initial_player2_used_roll_index,
+            result.initial_player2_roll,
+            result.initial_player2_final_roll,
+            result.player2_modifier,
+        )
+
+        init_text = f"{p1_initial_text}\n{p2_initial_text}"
+        embed.add_field(name="Initial Rolls", value=init_text, inline=False)
+
     roll_text = f"{p1_roll_text}\n{p2_roll_text}"
     embed.add_field(name="Dice Rolls", value=roll_text, inline=False)
+
+    if result.tie_rerolled:
+        embed.add_field(name="Tie Break", value="Initial roll was a tie. Rerolled to determine winner.", inline=False)
     
     # Winner
     winner_name = match.player1.username if result.winner_id == match.player1.user_id else match.player2.username

--- a/game_logic.py
+++ b/game_logic.py
@@ -38,6 +38,15 @@ class RoundResult:
     player2_all_rolls: List[int] = field(default_factory=list)
     player1_used_roll_index: int = -1
     player2_used_roll_index: int = -1
+    tie_rerolled: bool = False
+    initial_player1_roll: int = 0
+    initial_player2_roll: int = 0
+    initial_player1_final_roll: int = 0
+    initial_player2_final_roll: int = 0
+    initial_player1_all_rolls: List[int] = field(default_factory=list)
+    initial_player2_all_rolls: List[int] = field(default_factory=list)
+    initial_player1_used_roll_index: int = -1
+    initial_player2_used_roll_index: int = -1
 
 @dataclass
 class Match:
@@ -146,56 +155,77 @@ class ImperialDuelGame:
         # Get advantage states
         p1_adv, p2_adv = self.get_stance_relationship(p1_stance, p2_stance)
         
-        # Roll dice
-        p1_roll, p1_all_rolls, p1_used_index = self.roll_dice(p1_adv)
-        p2_roll, p2_all_rolls, p2_used_index = self.roll_dice(p2_adv)
-        
-        # Apply adjacency modifier if enabled
-        adjacency_applied = False
-        if match.adjacency_mod:
-            p1_final = self.apply_adjacency_mod(p1_roll, p1_stance, p2_stance)
-            p2_final = self.apply_adjacency_mod(p2_roll, p2_stance, p1_stance)
-            adjacency_applied = (p1_final != p1_roll) or (p2_final != p2_roll)
-        else:
-            p1_final = p1_roll
-            p2_final = p2_roll
-        
-        # Apply custom modifiers (match-wide and round-specific)
+        # Pre-compute modifiers that persist across rerolls
         p1_match_modifier = match.custom_modifiers.get(match.player1.user_id, 0)
         p2_match_modifier = match.custom_modifiers.get(match.player2.user_id, 0)
-        
+
         p1_round_modifier = match.round_modifiers.get(match.player1.user_id, 0)
         p2_round_modifier = match.round_modifiers.get(match.player2.user_id, 0)
-        
-        # Calculate total modifiers
+
         p1_modifier = p1_match_modifier + p1_round_modifier
         p2_modifier = p2_match_modifier + p2_round_modifier
 
-        # Apply Chaurus talent bonus if enabled
         if match.chaurus_talent:
             if "chaurus" in match.player1.username.lower():
                 p1_modifier += 1
             if "chaurus" in match.player2.username.lower():
                 p2_modifier += 1
-        
+
         custom_mod_applied = p1_modifier != 0 or p2_modifier != 0
+
+        # Roll dice with rerolls until a winner is determined
+        tie_rerolled = False
+        initial_captured = False
+        # Variables to store initial tie roll details
+        init_p1_roll = init_p2_roll = 0
+        init_p1_final = init_p2_final = 0
+        init_p1_all = []
+        init_p2_all = []
+        init_p1_used = -1
+        init_p2_used = -1
+
+        while True:
+            p1_roll, p1_all_rolls, p1_used_index = self.roll_dice(p1_adv)
+            p2_roll, p2_all_rolls, p2_used_index = self.roll_dice(p2_adv)
+
+            adjacency_applied = False
+            if match.adjacency_mod:
+                p1_final = self.apply_adjacency_mod(p1_roll, p1_stance, p2_stance)
+                p2_final = self.apply_adjacency_mod(p2_roll, p2_stance, p1_stance)
+                adjacency_applied = (p1_final != p1_roll) or (p2_final != p2_roll)
+            else:
+                p1_final = p1_roll
+                p2_final = p2_roll
+
+            if p1_modifier != 0:
+                p1_final = max(1, min(6, p1_final + p1_modifier))
+            if p2_modifier != 0:
+                p2_final = max(1, min(6, p2_final + p2_modifier))
+
+            if p1_final != p2_final:
+                break
+
+            if not initial_captured:
+                init_p1_roll = p1_roll
+                init_p2_roll = p2_roll
+                init_p1_final = p1_final
+                init_p2_final = p2_final
+                init_p1_all = p1_all_rolls
+                init_p2_all = p2_all_rolls
+                init_p1_used = p1_used_index
+                init_p2_used = p2_used_index
+                initial_captured = True
+
+            tie_rerolled = True
         
-        if p1_modifier != 0:
-            p1_final = max(1, min(6, p1_final + p1_modifier))
-        if p2_modifier != 0:
-            p2_final = max(1, min(6, p2_final + p2_modifier))
         
-        # Determine winner
+        # Determine winner (loop guarantees no tie)
         if p1_final > p2_final:
             winner_id = match.player1.user_id
             match.player1.score += 1
-        elif p2_final > p1_final:
+        else:
             winner_id = match.player2.user_id
             match.player2.score += 1
-        else:
-            # Tie - could implement tiebreaker rules here
-            winner_id = match.player1.user_id  # Default to player1 for now
-            match.player1.score += 1
         
         # Update last stances for no_repeat rule
         if match.no_repeat:
@@ -219,7 +249,16 @@ class ImperialDuelGame:
             player1_all_rolls=p1_all_rolls,
             player2_all_rolls=p2_all_rolls,
             player1_used_roll_index=p1_used_index,
-            player2_used_roll_index=p2_used_index
+            player2_used_roll_index=p2_used_index,
+            tie_rerolled=tie_rerolled,
+            initial_player1_roll=init_p1_roll,
+            initial_player2_roll=init_p2_roll,
+            initial_player1_final_roll=init_p1_final,
+            initial_player2_final_roll=init_p2_final,
+            initial_player1_all_rolls=init_p1_all,
+            initial_player2_all_rolls=init_p2_all,
+            initial_player1_used_roll_index=init_p1_used,
+            initial_player2_used_roll_index=init_p2_used
         )
         
         match.round_history.append(result)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -153,6 +153,43 @@ def test_no_repeat():
     
     print()
 
+def test_tie_reroll():
+    """Test that ties trigger a reroll"""
+    class FixedRollGame(ImperialDuelGame):
+        def __init__(self):
+            super().__init__()
+            self.roll_sequence = [3, 3, 5, 2]  # first two rolls tie, next decide winner
+            self.index = 0
+
+        def roll_dice(self, advantage_state):
+            roll = self.roll_sequence[self.index]
+            self.index += 1
+            return roll, [roll], -1
+
+    game = FixedRollGame()
+
+    player1 = Player(user_id=1, username="Alice")
+    player2 = Player(user_id=2, username="Bob")
+
+    match = Match(
+        channel_id=1,
+        player1=player1,
+        player2=player2,
+        best_of=3,
+        state=GameState.PICKING_STANCES
+    )
+
+    player1.declared_stances = ["Bagr", "Radae"]
+    player1.picked_stance = "Bagr"
+    player2.declared_stances = ["Bagr", "Radae"]
+    player2.picked_stance = "Bagr"  # Neutral matchup to keep rolls simple
+
+    result = game.resolve_round(match)
+    print(f"Tie rerolled: {result.tie_rerolled}")
+    assert result.tie_rerolled, "Reroll flag not set on tie"
+    assert result.initial_player1_roll == 3 and result.initial_player2_roll == 3
+    assert result.player1_roll == 5 and result.player2_roll == 2
+
 def main():
     """Run all tests"""
     print("🎯 Imperial Duel Game Logic Tests")
@@ -166,6 +203,7 @@ def main():
     test_dice_rolling()
     test_full_round()
     test_no_repeat()
+    test_tie_reroll()
     
     print("✅ All tests completed!")
     print("\nIf you see any ❌ marks above, there may be issues with the game logic.")


### PR DESCRIPTION
## Summary
- capture initial dice roll details when ties occur
- show initial rolls in embed before reroll
- test for tie reroll now checks initial and final rolls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683aecddbc8326b7dee062cd047981