### PR TITLE
Allow modifiers to exceed dice bounds

### DIFF
--- a/docs/MODIFIER_FEATURE.md
+++ b/docs/MODIFIER_FEATURE.md
@@ -37,7 +37,7 @@ This feature allows for dynamic gameplay adjustments and special event scenarios
 
 1. **Application**: Modifiers are applied to the final dice roll after all other calculations (advantage/disadvantage, adjacency modifiers)
 2. **Stacking**: Round and match modifiers stack with each other (e.g., a +1 round modifier and a +1 match modifier result in a +2 total modifier)
-3. **Range**: Modifiers are clamped to ensure final rolls stay within 1-6 bounds
+3. **Range**: Modifiers are applied directly, so final rolls can go below 1 or above 6
 4. **Persistence**:
    - Round modifiers are automatically cleared after each round
    - Match modifiers remain active for the entire match until changed or removed
@@ -60,7 +60,7 @@ This feature allows for dynamic gameplay adjustments and special event scenarios
 - Match modifiers are stored in the `Match.custom_modifiers` dictionary and persist for the entire match
 - Both types of modifiers are applied in `ImperialDuelGame.resolve_round()` after adjacency modifiers
 - Tracked in `RoundResult` for display purposes
-- Bounds checking ensures rolls stay within 1-6 range
+- Rolls are not clamped after modifiers; values may fall outside 1-6
 
 ## Use Cases
 

--- a/game_logic.py
+++ b/game_logic.py
@@ -133,9 +133,9 @@ class ImperialDuelGame:
     def apply_adjacency_mod(self, roll: int, stance1: str, stance2: str) -> int:
         """Apply adjacency modifier to roll"""
         if self.are_stances_adjacent(stance1, stance2):
-            return max(1, min(6, roll + 1))
+            return roll + 1
         elif self.are_stances_opposite(stance1, stance2):
-            return max(1, min(6, roll - 1))
+            return roll - 1
         return roll
     
     def resolve_round(self, match: Match) -> RoundResult:
@@ -181,9 +181,9 @@ class ImperialDuelGame:
         custom_mod_applied = p1_modifier != 0 or p2_modifier != 0
         
         if p1_modifier != 0:
-            p1_final = max(1, min(6, p1_final + p1_modifier))
+            p1_final = p1_final + p1_modifier
         if p2_modifier != 0:
-            p2_final = max(1, min(6, p2_final + p2_modifier))
+            p2_final = p2_final + p2_modifier
         
         # Determine winner
         if p1_final > p2_final:

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -110,7 +110,7 @@ def test_modifiers():
     assert result4.player2_modifier == -2, f"Expected player2 modifier to be -2, got {result4.player2_modifier}"
     
     # Test edge cases
-    print("\n5. Testing edge cases (rolls clamped to 1-6):")
+    print("\n5. Testing edge cases (rolls may exceed 1-6):")
     # Force some specific rolls by testing multiple times
     for i in range(5):
         match.current_round = 1
@@ -124,10 +124,14 @@ def test_modifiers():
         
         result = game.resolve_round(match)
         print(f"   Test {i+1}: P1: {result.player1_roll} -> {result.player1_final_roll}, P2: {result.player2_roll} -> {result.player2_final_roll}")
-        
-        # Verify rolls are within bounds
-        assert 1 <= result.player1_final_roll <= 6, f"Player1 final roll {result.player1_final_roll} out of bounds"
-        assert 1 <= result.player2_final_roll <= 6, f"Player2 final roll {result.player2_final_roll} out of bounds"
+
+        # Verify modifiers were applied without clamping
+        assert result.player1_final_roll - result.player1_roll == 3, (
+            f"Player1 diff {result.player1_final_roll - result.player1_roll} != 3"
+        )
+        assert result.player2_final_roll - result.player2_roll == -3, (
+            f"Player2 diff {result.player2_final_roll - result.player2_roll} != -3"
+        )
 
     print("\n✅ All tests passed! Modifier functionality (match and round) is working correctly.")
 


### PR DESCRIPTION
## Summary
- remove clamping from adjacency and custom modifiers
- update tests for new modifier behaviour
- document that modifiers may push rolls outside the 1-6 range

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686847fd9054832699bf2a9b9bb96589