### PR TITLE
Allow modifiers to exceed dice range

### DIFF
--- a/docs/MODIFIER_FEATURE.md
+++ b/docs/MODIFIER_FEATURE.md
@@ -37,7 +37,7 @@ This feature allows for dynamic gameplay adjustments and special event scenarios
 
 1. **Application**: Modifiers are applied to the final dice roll after all other calculations (advantage/disadvantage, adjacency modifiers)
 2. **Stacking**: Round and match modifiers stack with each other (e.g., a +1 round modifier and a +1 match modifier result in a +2 total modifier)
-3. **Range**: Modifiers are clamped to ensure final rolls stay within 1-6 bounds
+3. **Range**: Modifiers are applied directly, so final rolls may exceed the normal 1-6 dice values
 4. **Persistence**:
    - Round modifiers are automatically cleared after each round
    - Match modifiers remain active for the entire match until changed or removed
@@ -60,7 +60,7 @@ This feature allows for dynamic gameplay adjustments and special event scenarios
 - Match modifiers are stored in the `Match.custom_modifiers` dictionary and persist for the entire match
 - Both types of modifiers are applied in `ImperialDuelGame.resolve_round()` after adjacency modifiers
 - Tracked in `RoundResult` for display purposes
-- Bounds checking ensures rolls stay within 1-6 range
+- Results may be lower than 1 or higher than 6 when modifiers are used
 
 ## Use Cases
 

--- a/game_logic.py
+++ b/game_logic.py
@@ -194,9 +194,9 @@ class ImperialDuelGame:
                 p2_final = p2_roll
 
             if p1_modifier != 0:
-                p1_final = max(1, min(6, p1_final + p1_modifier))
+                p1_final = p1_final + p1_modifier
             if p2_modifier != 0:
-                p2_final = max(1, min(6, p2_final + p2_modifier))
+                p2_final = p2_final + p2_modifier
 
             if first_iteration:
                 first_p1_roll = p1_roll

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -110,7 +110,7 @@ def test_modifiers():
     assert result4.player2_modifier == -2, f"Expected player2 modifier to be -2, got {result4.player2_modifier}"
     
     # Test edge cases
-    print("\n5. Testing edge cases (rolls clamped to 1-6):")
+    print("\n5. Testing edge cases (no clamping):")
     # Force some specific rolls by testing multiple times
     for i in range(5):
         match.current_round = 1
@@ -124,10 +124,14 @@ def test_modifiers():
         
         result = game.resolve_round(match)
         print(f"   Test {i+1}: P1: {result.player1_roll} -> {result.player1_final_roll}, P2: {result.player2_roll} -> {result.player2_final_roll}")
-        
-        # Verify rolls are within bounds
-        assert 1 <= result.player1_final_roll <= 6, f"Player1 final roll {result.player1_final_roll} out of bounds"
-        assert 1 <= result.player2_final_roll <= 6, f"Player2 final roll {result.player2_final_roll} out of bounds"
+
+        # Verify modifiers were applied without clamping
+        assert result.player1_final_roll == result.player1_roll + 3, (
+            f"Player1 final roll {result.player1_final_roll} unexpected"
+        )
+        assert result.player2_final_roll == result.player2_roll - 3, (
+            f"Player2 final roll {result.player2_final_roll} unexpected"
+        )
 
     print("\n✅ All tests passed! Modifier functionality (match and round) is working correctly.")
 


### PR DESCRIPTION
## Summary
- remove clamping when applying modifiers so rolls can go outside 1-6
- document that modifiers may push results beyond normal dice range
- update tests for new modifier behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686848fadcac83269d79bfc07b3ef603