### PR TITLE
Update tie rule in docs and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Each stance has:
 5. Apply adjacency modifier if enabled:
    - **Adjacent stances**: +1 to roll
    - **Opposite stances**: -1 to roll
-6. Higher roll wins the round
+6. Higher roll wins the round. If both rolls are tied, reroll until a winner is determined.
 7. First to required wins takes the match
 
 ### Optional Variants

--- a/bot.py
+++ b/bot.py
@@ -261,7 +261,7 @@ async def rules_command(interaction: discord.Interaction):
             "**Advantage**: Roll 2d6, keep higher\n"
             "**Neutral**: Roll 1d6\n"
             "**Disadvantage**: Roll 2d6, keep lower\n"
-            "\n*Ties go to the challenger*"
+            "\n*If rolls tie, reroll until a winner is determined*"
         ),
         inline=True
     )

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -130,6 +130,7 @@ Your friend can then accept with:
 - Advantage = roll 2d6, take higher
 - Disadvantage = roll 2d6, take lower  
 - Neutral = roll 1d6
+- Ties: reroll until there is a winner
 
 **Variants**:
 - **No Repeat**: Can't use same stance twice in a row


### PR DESCRIPTION
## Summary
- clarify tie resolution in README and Quickstart guide
- update `/rules` command text so ties reroll until a winner is found

## Testing
- `python tests/test_game.py`

------
https://chatgpt.com/codex/tasks/task_e_68684ba786988326afabd053c77bbc48