### PR TITLE
Use role ID for triple stance toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Force-end a match (moderators only).
 ### `/duel chaurus_talent_toggle`
 Toggle a persistent +1 roll bonus for players with "Chaurus" in their nickname (moderators only).
 
-### `/duel triple_stance_toggle word`
-Allow players with `word` in their nickname to declare three stances instead of two (moderators only).
+### `/duel triple_stance_toggle role_id`
+Allow members with the specified role to declare three stances instead of two (moderators only).
 
 ## Game Rules
 

--- a/game_logic.py
+++ b/game_logic.py
@@ -60,7 +60,7 @@ class Match:
     adjacency_mod: bool = False
     bait_switch: bool = False
     chaurus_talent: bool = False
-    triple_stance_word: str = ''
+    triple_stance_role_id: int = 0
     round_history: List[RoundResult] = field(default_factory=list)
     last_stances: Dict[int, str] = field(default_factory=dict)  # user_id -> last stance used
     custom_modifiers: Dict[int, int] = field(default_factory=dict)  # user_id -> modifier value (match-wide)

--- a/settings.json
+++ b/settings.json
@@ -1,1 +1,1 @@
-{"chaurus_talent": false, "triple_stance_word": "", "moderators": [203229662967627777]}
+{"chaurus_talent": false, "moderators": [203229662967627777], "triple_stance_role_id": 0}

--- a/settings.py
+++ b/settings.py
@@ -4,7 +4,7 @@ import os
 SETTINGS_FILE = os.path.join(os.path.dirname(__file__), 'settings.json')
 DEFAULT_SETTINGS = {
     'chaurus_talent': False,
-    'triple_stance_word': '',
+    'triple_stance_role_id': 0,
     'moderators': []
 }
 

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -178,9 +178,9 @@ def test_settings_persistence():
     settings['chaurus_talent'] = original
     save_settings(settings)
 
-def test_triple_stance_word():
-    """Test triple stance word functionality"""
-    print("\n8. Testing triple stance word:")
+def test_triple_stance_role():
+    """Test triple stance role functionality"""
+    print("\n8. Testing triple stance role:")
     game = ImperialDuelGame()
 
     player1 = Player(user_id=1, username="TripleHero")
@@ -192,7 +192,7 @@ def test_triple_stance_word():
         player2=player2,
         best_of=3,
         state=GameState.DECLARING_STANCES,
-        triple_stance_word="triple"
+        triple_stance_role_id=123
     )
 
     player1.declared_stances = ["Bagr", "Radae", "Darda"]
@@ -202,4 +202,4 @@ if __name__ == "__main__":
     test_modifiers()
     test_chaurus_talent()
     test_settings_persistence()
-    test_triple_stance_word()
+    test_triple_stance_role()


### PR DESCRIPTION
## Summary
- change triple stance toggle to accept a role ID instead of a username word
- store `triple_stance_role_id` in settings and match data
- update help text and README
- adjust tests for the new role-based parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751a3198788326a63959d895e2b371